### PR TITLE
sidebar slide animation

### DIFF
--- a/web/src/components/SiteNav.tsx
+++ b/web/src/components/SiteNav.tsx
@@ -33,22 +33,10 @@ const SiteNav = () => {
 
     const [isOpen, setIsOpen] = useState(false)
 
-    const openNav = () => {
-        document.getElementById('sidebar').style.width = '300px'
-        document.getElementById('main').style.marginLeft = '300px'
-    }
-
-    const closeNav = () => {
-        document.getElementById('sidebar').style.width = '0'
-        document.getElementById('main').style.marginLeft = '0'
-    }
-
     const toggleOpenSidebar = () => {
         if (isOpen) {
-            closeNav()
             setIsOpen(false)
         } else {
-            openNav()
             setIsOpen(true)
         }
     }
@@ -58,7 +46,7 @@ const SiteNav = () => {
             <div id="nav" className="nav">
                 <BiMenu data-cy="sidebar-btn" size={40} className="sidebar-menu-btn" onClick={toggleOpenSidebar} />
             </div>
-            <SidebarContainer options={OPTIONS} />
+            <SidebarContainer options={OPTIONS} isOpen={isOpen} />
         </>
     )
 }

--- a/web/src/components/common/sidebar/SidebarContainer.tsx
+++ b/web/src/components/common/sidebar/SidebarContainer.tsx
@@ -10,12 +10,18 @@ import SidebarBody from './SidebarBody'
  */
 const SidebarContainer = ({
     options,
+    isOpen,
 }: {
     options: SidebarMenuOptions
+    isOpen: boolean
 }) => {
 
     return (
-        <div className="sidebar" id="sidebar" data-cy="sidebar">
+        <div
+          className={`sidebar ${(isOpen ? 'transform translate-x-0' : 'transform -translate-x-full')}`}
+          id="sidebar"
+          data-cy="sidebar"
+        >
             <SidebarBody>
                 <SidebarBodyText />
                 <SidebarBodyList options={options} />

--- a/web/src/css/index.css
+++ b/web/src/css/index.css
@@ -192,7 +192,6 @@ h1 {
     @apply bg-gray-800;
     @apply my-4;
     @apply sticky top-12;
-    @apply z-10;
     @apply w-full;
     @apply block text-center;
 }
@@ -348,12 +347,13 @@ main {
 /* Sidebar */
 .sidebar {
     @apply h-full;
-    @apply w-0;
+    @apply w-80;
     @apply fixed;
     @apply z-10;
     @apply top-0 left-0;
     @apply overflow-clip overflow-hidden;
     @apply bg-gray-600;
+    @apply transition;
 }
 .sidebar-menu-btn {
     @apply pl-2;
@@ -377,7 +377,7 @@ main {
     @apply align-middle;
 }
 .sidebar-menu-option-icon {
-    @apply pl-8;
+    @apply pl-2;
     @apply inline-block;
     @apply align-middle;
 }


### PR DESCRIPTION
Using CSS only (Tailwind, in this case), make the sidebar slide in/out.

Uses `transition`, `translate`s, and slightly alters how the `isOpen` logic was previously used.