### PR TITLE
hide contact form when mailer unavailable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/web/next/pages/about.tsx
+++ b/web/next/pages/about.tsx
@@ -23,8 +23,27 @@ interface AboutPageProps {
   employers: EmployerProps[]
 }
 
+// TODO: 
+const HEALTHCHECK_ENDPOINT = `http://localhost:3001/ping`
+
 const About: NextPage<AboutPageProps> = (props) => {
   const { creators, employers } = props
+
+  const showContactForm = React.useMemo(() => {
+    try {
+      fetch(HEALTHCHECK_ENDPOINT, {
+        mode: 'cors',
+        method: 'GET',
+      })
+      .then(res => {
+        if (res.status === 200) return true
+        return false
+      })
+      .catch(e => false)
+    } catch (e) {
+      return false
+    }
+  }, [])
 
   const creator = creators[0]
 
@@ -89,12 +108,15 @@ const About: NextPage<AboutPageProps> = (props) => {
               )
             })}
         </div>
-        <div className='contact'>
-          <div className='section-title'>
-            <h2>Contact</h2>
+        {showContactForm && (
+          <div className='contact'>
+            <div className='section-title'>
+              <h2>Contact</h2>
+            </div>
+            <ContactForm />
           </div>
-          <ContactForm />
-        </div>
+        )}
+        
       </PageLayout>
     )
 }


### PR DESCRIPTION
This ensures that the contact form is only shown when the `mailer` server is available (repo TBD).