### PR TITLE
enable vercel speed insights

### DIFF
--- a/web/next/components/layout/PageLayout.tsx
+++ b/web/next/components/layout/PageLayout.tsx
@@ -4,6 +4,7 @@ import { Container } from "react-bootstrap"
 import SiteNavigation from './nav/NavBar'
 import Sidebar from './sidebar/Sidebar'
 import Image from 'next/image'
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 interface PageLayoutProps {
     pageTitle?: string
@@ -53,6 +54,7 @@ export const PageLayout = ({
             </Head>
             <main>
               {children}
+              <SpeedInsights />
             </main>
           </Container>
         </div>

--- a/web/next/components/layout/PageLayout.tsx
+++ b/web/next/components/layout/PageLayout.tsx
@@ -4,7 +4,7 @@ import { Container } from "react-bootstrap"
 import SiteNavigation from './nav/NavBar'
 import Sidebar from './sidebar/Sidebar'
 import Image from 'next/image'
-import { SpeedInsights } from '@vercel/speed-insights/next';
+import { SpeedInsights } from '@vercel/speed-insights/next'
 
 interface PageLayoutProps {
     pageTitle?: string

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -25,6 +25,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
+    "@vercel/speed-insights": "^1.0.1",
     "bootstrap": "5.1.3",
     "clsx": "^1.1.1",
     "cypress": "13.5.0",

--- a/web/next/yarn.lock
+++ b/web/next/yarn.lock
@@ -849,6 +849,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@vercel/speed-insights@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.0.1.tgz#ea801f639594cbd5121d80a0ea1103e08ac5edc9"
+  integrity sha512-cm8KTTsDgS1AbWsgIEZuMoyPUjclzeqJihyLp0tnA21B/x9iTE8hu2S5zM+/DBzihuHxWL1dx9pCWk22ctMFWQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
Enables Vercel's [Speed Insights](https://vercel.com/docs/speed-insights) feature, which is free for a single Hobby Tier site.