### PR TITLE
lazy load embedded images; make header images priority

### DIFF
--- a/web/next/.eslintrc.yml
+++ b/web/next/.eslintrc.yml
@@ -44,6 +44,7 @@ rules:
   # TODO: turn these on and fix errors, if needed
   jsx-a11y/click-events-have-key-events: "off"
   jsx-a11y/no-static-element-interactions: "off"
+  jsx-a11y/alt-text: "off"
   import/prefer-default-export: "off"
   import/extensions: "off"
   react/require-default-props: "off"

--- a/web/next/components/layout/PageLayout.tsx
+++ b/web/next/components/layout/PageLayout.tsx
@@ -41,6 +41,7 @@ export const PageLayout = ({
                   height={1080}
                   width={1920}
                   alt='hero-image'
+                  priority={true}
                 />
               </div>
             </div>

--- a/web/next/components/pages/about/EmployerDetails.tsx
+++ b/web/next/components/pages/about/EmployerDetails.tsx
@@ -43,6 +43,8 @@ export const EmployerDetails: FunctionComponent<EmployerProps> = ({
                 height={48}
                 width={48}
                 alt={`employer-logo-${kebabCase(name!.toLowerCase())}`}
+                placeholder='blur'
+                blurDataURL={imageUrl}
             />
           </div>
           <div className={styles.employerNameAndDates}>

--- a/web/next/next.config.js
+++ b/web/next/next.config.js
@@ -6,6 +6,19 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },
+  // headers() {
+  //   return [
+  //     {
+  //       source: '/blog/:slug',
+  //       headers: [
+  //         { key: "Access-Control-Allow-Credentials", value: "true" },
+  //         { key: "Access-Control-Allow-Origin", value: "https://*.apicdn.sanity.io" },
+  //         { key: "Access-Control-Allow-Methods", value: "GET,DELETE,PATCH,POST,PUT" },
+  //         { key: "Access-Control-Allow-Headers", value: "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" },
+  //       ]
+  //     }
+  //   ]
+  // },
   images: {
     remotePatterns: [
       {

--- a/web/next/next.config.js
+++ b/web/next/next.config.js
@@ -6,19 +6,6 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },
-  // headers() {
-  //   return [
-  //     {
-  //       source: '/blog/:slug',
-  //       headers: [
-  //         { key: "Access-Control-Allow-Credentials", value: "true" },
-  //         { key: "Access-Control-Allow-Origin", value: "https://*.apicdn.sanity.io" },
-  //         { key: "Access-Control-Allow-Methods", value: "GET,DELETE,PATCH,POST,PUT" },
-  //         { key: "Access-Control-Allow-Headers", value: "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" },
-  //       ]
-  //     }
-  //   ]
-  // },
   images: {
     remotePatterns: [
       {

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -17,7 +17,6 @@
     "@portabletext/react": "^3.0.11",
     "@reduxjs/toolkit": "^1.7.2",
     "@sanity/client": "^3.2.0",
-    "@sanity/image-url": "^1.0.2",
     "@types/node": "17.0.17",
     "@types/react": "17.0.39",
     "@types/react-bootstrap": "^0.32.29",

--- a/web/next/pages/about.tsx
+++ b/web/next/pages/about.tsx
@@ -60,6 +60,8 @@ const About: NextPage<AboutPageProps> = (props) => {
               src={creator.imageUrl}
               layout='fill'
               alt='creator-image'
+              placeholder='blur'
+              blurDataURL={creator.imageUrl}
             />
           </div>
           <div className='creator-details'>

--- a/web/next/pages/blog/ArticleBodyImage.tsx
+++ b/web/next/pages/blog/ArticleBodyImage.tsx
@@ -5,14 +5,10 @@ import client from '../../sanity/client'
 
 interface ArticleBodyImageProps {
     imageRef: string
-    height: number
-    width: number
 }
 
 export const ArticleBodyImage: React.FC<ArticleBodyImageProps> = ({
     imageRef,
-    height,
-    width,
 }) => {
 
     const [loading, setLoading] = useState(true)
@@ -50,18 +46,21 @@ export const ArticleBodyImage: React.FC<ArticleBodyImageProps> = ({
 
     return (
       <Image
-            src={imgUrl}
-            height={height}
-            width={width}
-            alt={`embedded-image-${imageRef}`}
-            placeholder='blur'
-            // /**
-            //  * For blur Data URLs, it's recommended to use an image that's 10x10 pixels or less
-            //  * 
-            //  * @see https://nextjs.org/docs/pages/api-reference/components/image#blurdataurl
-            //  */
-            blurDataURL={blurImgUrl}
-        />
+        src={imgUrl}
+        height={0}
+        width={0}
+        sizes="100vw"
+        alt={`embedded-image-${imageRef}`}
+        placeholder='blur'
+        // /**
+        //  * For blur Data URLs, it's recommended to use an image that's 10x10 pixels or less
+        //  * 
+        //  * @see https://nextjs.org/docs/pages/api-reference/components/image#blurdataurl
+        //  */
+        blurDataURL={blurImgUrl}
+        style={{ width: `100%`, height: `auto` }}
+    />
+
     )
 }
 

--- a/web/next/pages/blog/ArticleBodyImage.tsx
+++ b/web/next/pages/blog/ArticleBodyImage.tsx
@@ -64,3 +64,5 @@ export const ArticleBodyImage: React.FC<ArticleBodyImageProps> = ({
         />
     )
 }
+
+export default ArticleBodyImage

--- a/web/next/pages/blog/ArticleBodyImage.tsx
+++ b/web/next/pages/blog/ArticleBodyImage.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+import Image from 'next/image'
+import { useEffect } from 'react'
+import client from '../../sanity/client'
+
+interface ArticleBodyImageProps {
+    imageRef: string
+    height: number
+    width: number
+}
+
+export const ArticleBodyImage: React.FC<ArticleBodyImageProps> = ({
+    imageRef,
+    height,
+    width,
+}) => {
+
+    const [loading, setLoading] = useState(true)
+    const [imgUrl, setImgUrl] = useState(null as unknown as string)
+    const [blurImgUrl, setBlurImgUrl] = useState(null as unknown as string)
+
+    useEffect(() => {
+        async function fetchImageData() {
+            const imageData = await client.fetch(`*[_type == "sanity.imageAsset" && _id == $ref][0]{
+                metadata,
+                url
+            }`, { ref: imageRef }) as {
+                // There are more fields available here, but we only need the lqip field
+                metadata: {
+                    lqip: string    // A 20x20, base64 encoding of the image, useful for placeholders
+                },
+                url: string     // The URL to the original, full-resolution asset
+            }
+            setImgUrl(imageData.url)
+            setBlurImgUrl(imageData.metadata.lqip)
+        }
+
+        fetchImageData()
+        .then(() => {
+            // If either one is loaded, we know they both are (NOTE: the imgUrl being defined does not mean the image has rendered - just that the URL is ready to be used)
+            if (imgUrl || blurImgUrl) {
+                setLoading(false)
+            }
+        })
+    })
+
+    if (loading) {
+        return <div>Loading image...</div>
+    }
+
+    return (
+      <Image
+            src={imgUrl}
+            height={height}
+            width={width}
+            alt={`embedded-image-${imageRef}`}
+            placeholder='blur'
+            // /**
+            //  * For blur Data URLs, it's recommended to use an image that's 10x10 pixels or less
+            //  * 
+            //  * @see https://nextjs.org/docs/pages/api-reference/components/image#blurdataurl
+            //  */
+            blurDataURL={blurImgUrl}
+        />
+    )
+}

--- a/web/next/pages/blog/[slug].tsx
+++ b/web/next/pages/blog/[slug].tsx
@@ -5,11 +5,8 @@ import client from '../../sanity/client'
 import { Article } from '../../types/sanity'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import Link from 'next/link'
-import createImageUrlBuilder from '@sanity/image-url'
-import Image from 'next/image'
 import { AnchoredHeading } from '../../components/shared/AnchoredHeading'
-
-const imageBuilder = createImageUrlBuilder(client)
+import { ArticleBodyImage } from './ArticleBodyImage'
 
 interface BlogPostProps {
   article: Article & {
@@ -18,8 +15,6 @@ interface BlogPostProps {
   }
 }
 
-const urlForImage = (source) =>
-  imageBuilder.image(source).auto(`format`).fit(`max`)
 
 const blogPostComponents = {
   types: {
@@ -30,28 +25,11 @@ const blogPostComponents = {
       )
     },
     image: ({value}) => {
-      const imageHeight = 600
-      const imageWidth = 1200
-
-      /**
-       * NOTE: Sanity's docs on presenting images DOES NOT cover presenting images this way. When you have images embedded in body
-       * content, as article images are, you do NOT have access to a normal "SanityReference" object as their docs assume. Fortunately,
-       * the `image()` API accepts a `_ref` value in addition to the types discussed in the docs. Simply target `_ref` as we do here
-       * in order to render images within block content.
-       * 
-       * @see https://www.sanity.io/docs/presenting-images
-       */
-      const imgUrl = urlForImage(value.asset[`_ref`]).auto(`format`).url()
-      if (!imgUrl) {
-        return null
-      }
-
       return (
-        <Image
-          src={imgUrl}
-          height={imageHeight}
-          width={imageWidth}
-          alt={`embedded-image-${value[`_key`]}`}
+        <ArticleBodyImage
+          imageRef={value.asset[`_ref`]}
+          height={600}
+          width={1200}
         />
       )
     },

--- a/web/next/pages/blog/[slug].tsx
+++ b/web/next/pages/blog/[slug].tsx
@@ -28,8 +28,6 @@ const blogPostComponents = {
       return (
         <ArticleBodyImage
           imageRef={value.asset[`_ref`]}
-          height={600}
-          width={1200}
         />
       )
     },

--- a/web/next/sanity/client.ts
+++ b/web/next/sanity/client.ts
@@ -4,5 +4,5 @@ export default client({
     projectId: process.env.SANITY_PROJECT,
     dataset: process.env.SANITY_DATASET,
     useCdn: true, // `false` if you want to ensure fresh data
-    apiVersion: `v2023-06-12`
+    apiVersion: `v2023-06-12`,
 })

--- a/web/next/yarn.lock
+++ b/web/next/yarn.lock
@@ -554,11 +554,6 @@
   resolved "https://registry.yarnpkg.com/@sanity/generate-help-url/-/generate-help-url-3.0.0.tgz#60e9cba61b82103ea3761730a53cd9310b98892d"
   integrity sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA==
 
-"@sanity/image-url@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.2.tgz#1ff7259e9bad6bfca4169f21c53a4123f6ac78c3"
-  integrity sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ==
-
 "@sanity/timed-out@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@sanity/timed-out/-/timed-out-4.0.2.tgz#c9f61f9a1609baa1eb3e4235a24ea2a775022cdf"


### PR DESCRIPTION
Implements all code necessary to lazy-load images for a NextJS site, _SPECIFICALLY_ for images that are initially only available as [Portable Text](https://www.sanity.io/docs/presenting-block-text) blocks.

## Why is Portable Text a complication?

Portable text is really convenient for _most_ things. However, for image blocks, getting lazy loading the "right" way is hard to nail down for a number of reasons:
1. You don't have access to all of the image data - just reference information used internally by Sanity
    * You need an image URL to use with the `Image` component, which is not immediately-available in this data
        * Either use [`@sanity/image-url`](https://www.npmjs.com/package/@sanity/image-url) to generate the URL with many different configuration options OR...
        * Manually-query the full image data using the `_ref` value
            * This is the route I opted for since the image data also includes a `metadata.lqip` field, which is a pre-made base64 encoded 20x20 image that's useful for placeholders (e.g., the blur image used as part of lazy loading)
2. There is no apparent way to load the embedded images via the base query used in [`getStaticProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props)
    * The closest you can get is by querying the field that actually contains the Portable Text blocks - in my case, the `body` field
3. The `metadata.lqip` field isn't mentioned much in the docs, but it does seem to exist for the purpose of placeholder images
    * The docs seem to imply you should use the `@sanity/image-url` package, but doing so requires you to make some faulty assumptions about the images being generated (namely, there is an implicit assumption that they are all the same size, which leads to funky resolutions in many images)
    * To me, it seems better to use the base image asset, then use something like `sharp` to resize the image _correctly_ (instead of with flat height/width values); while the resize logic is happening, lazy load should take effect, but this is not currently fully configured yet

## CORS Considerations

`ArticleBodyImage` actively-queries the CDN for the images on-the-fly (from the browser), meaning, for that component, the request is not originating from the same origin (as requests from `getStaticProps` are). As a result, the request from this component will be blocked unless you've added the domain your application is running at as an allowed origin.

**If you encounter issues with CORS when fetching data from Sanity CMS, make sure you've added the correct allowed origin in your Sanity project Dashboard (under the "API" tab).**