### PR TITLE
Load article-embedded image data during build time

### DIFF
--- a/web/next/pages/blog/ArticleBodyImage.tsx
+++ b/web/next/pages/blog/ArticleBodyImage.tsx
@@ -1,63 +1,31 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Image from 'next/image'
-import { useEffect } from 'react'
-import client from '../../sanity/client'
 
 interface ArticleBodyImageProps {
-    imageRef: string
+    imgIndex: number
+    imgUrl: string,
+    blurImg: string
 }
 
 export const ArticleBodyImage: React.FC<ArticleBodyImageProps> = ({
-    imageRef,
+    imgIndex,
+    imgUrl,
+    blurImg
 }) => {
-
-    const [loading, setLoading] = useState(true)
-    const [imgUrl, setImgUrl] = useState(null as unknown as string)
-    const [blurImgUrl, setBlurImgUrl] = useState(null as unknown as string)
-
-    useEffect(() => {
-        async function fetchImageData() {
-            const imageData = await client.fetch(`*[_type == "sanity.imageAsset" && _id == $ref][0]{
-                metadata,
-                url
-            }`, { ref: imageRef }) as {
-                // There are more fields available here, but we only need the lqip field
-                metadata: {
-                    lqip: string    // A 20x20, base64 encoding of the image, useful for placeholders
-                },
-                url: string     // The URL to the original, full-resolution asset
-            }
-            setImgUrl(imageData.url)
-            setBlurImgUrl(imageData.metadata.lqip)
-        }
-
-        fetchImageData()
-        .then(() => {
-            // If either one is loaded, we know they both are (NOTE: the imgUrl being defined does not mean the image has rendered - just that the URL is ready to be used)
-            if (imgUrl || blurImgUrl) {
-                setLoading(false)
-            }
-        })
-    })
-
-    if (loading) {
-        return <div>Loading image...</div>
-    }
-
     return (
       <Image
         src={imgUrl}
         height={0}
         width={0}
         sizes="100vw"
-        alt={`embedded-image-${imageRef}`}
+        alt={`article-image-${imgIndex}`}
         placeholder='blur'
         // /**
         //  * For blur Data URLs, it's recommended to use an image that's 10x10 pixels or less
         //  * 
         //  * @see https://nextjs.org/docs/pages/api-reference/components/image#blurdataurl
         //  */
-        blurDataURL={blurImgUrl}
+        blurDataURL={blurImg}
         style={{ width: `100%`, height: `auto` }}
     />
 


### PR DESCRIPTION
Load images during build time instead of querying for them from the client per-image.

I was rushing through things before and was just trying to get something up and running. However, the previous implementation was significantly-flawed in that it doubled up the requests per image; once for the call that the client made and again to load the image via the URL that was returned from the API call.

Now, there should only be one client-side call that is fetching the image by its URL. _There should no longer be any Sanity client requests being made from the browser_.